### PR TITLE
Revert "fnf-psychengine: Update flixel-5.6.2.zip to 5.9.0"

### DIFF
--- a/psychengine-haxelib-dependencies.yml
+++ b/psychengine-haxelib-dependencies.yml
@@ -19,8 +19,8 @@
       version-query: .tag_name
       url-query: .assets[] | select(.name==\"openfl-haxelib.zip\") | .browser_download_url
   - type: file
-    url: https://api.github.com/repos/HaxeFlixel/flixel/zipball/refs/tags/5.9.0
-    sha256: 3edfdc766293eda247212a240c5d90c08ea0bc5dedc34fc010cc0583aa878996
+    url: https://api.github.com/repos/HaxeFlixel/flixel/zipball/refs/tags/5.8.0
+    sha256: c747811e666c5397352d1894f6db1cdc7221c3dd2ad8e14d0d689cc3d2dcb9e3
     dest: psychengine-deps/
     dest-filename: flixel-5.6.2.zip
     x-checker-data:


### PR DESCRIPTION
Reverts flathub/io.github.shadowmario.fnf-psychengine#21